### PR TITLE
Add more descriptive Exception Stack Trace and include option to log database queries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "Xethron/l4-to-string": "1.*"
     },
     "require-dev": {
         "anlutro/l4-config-mock": "dev-master",

--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -39,13 +39,16 @@ class ErrorHandler
 		$url = Request::fullUrl();
 		$client = Request::getClientIp();
 
-		$logstr = "Uncaught Exception (handled by L4SmartErrors)\nURL: $url -- Route: $route -- Client: $client\n" . $exception;
+		$logstr = "Uncaught Exception (handled by L4SmartErrors)\nURL: $url -- Route: $route -- Client: $client\n";
+		$logstr .= \Xethron\L4ToString::exception( $exception );
 
 		// get any input and log it
 		$input = Request::all();
 		if (!empty($input)) {
 			$logstr .= 'Input: ' . json_encode($input);
 		}
+
+		if ( Config::get('smarterror::log-queries') ) $logstr .= "MySQL Queries:\n". \Xethron\L4ToString::queryLog();
 
 		Log::error($logstr);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -31,4 +31,7 @@ return array(
 	// The PHP date() format that should be used. Leave as null for default
 	// Default: Y-m-d H:i:s e
 	'date-format' => null,
+
+	// Should Database Queries be logged?
+	'log-queries' => false,
 );

--- a/src/views/error-email-plain.blade.php
+++ b/src/views/error-email-plain.blade.php
@@ -7,7 +7,7 @@ In {{ $exception->getFile() }} on line {{ $exception->getLine() }}
 
 Stack trace
 ===========
-{{ $exception->getTraceAsString() }}
+{{ \Xethron\L4ToString::exception( $exception ) }}
 
 @if ($previous = $exception->getPrevious())
 Previous exception
@@ -22,4 +22,10 @@ Input
 @foreach($input as $key => $val)
 {{ $key }}: {{ $val }}
 @endforeach
+@endif
+
+@if (Config::get('smarterror::log-queries'))
+MySQL Queries
+=============
+{{ \Xethron\L4ToString::queryLog() }}
 @endif

--- a/src/views/error-email.blade.php
+++ b/src/views/error-email.blade.php
@@ -17,7 +17,7 @@
 </p>
 
 <p><b>Stack trace</b></p>
-<p><pre style="white-space:pre-wrap;">{{ nl2br($exception->getTraceAsString()) }}</pre></p>
+<p><pre style="white-space:pre-wrap;">{{ \Xethron\L4ToString::exception( $exception ) }}</pre></p>
 
 @if ($previous = $exception->getPrevious())
 <p>
@@ -38,4 +38,9 @@
 	<b>Input</b><br>
 	<?php var_dump($input) ?>
 </p>
+@endif
+
+@if (Config::get('smarterror::log-queries'))
+	<p><b>MySQL Queries</b></p>
+	<p><pre style="white-space:pre-wrap;">{{ \Xethron\L4ToString::queryLog() }}</pre></p>
 @endif


### PR DESCRIPTION
Exception Stack Traces will now be printed out without cutting off valuable pieces of information.
The Stack Trace will also include the variables that where passed.

There is an option to turn on database query logging. Its been set to default as it will cause errors if the database isn't setup yet.

This was tested in L4.1 without an email server, but I'm sure the emails will work.
