### PR TITLE
Add user agent

### DIFF
--- a/src/anlutro/L4SmartErrors/AppInfoGenerator.php
+++ b/src/anlutro/L4SmartErrors/AppInfoGenerator.php
@@ -45,6 +45,7 @@ class AppInfoGenerator
 			$this->addData('HTTP method', $this->app['request']->getMethod());
 			$this->addData('Referer', $this->app['request']->header('referer') ?: 'None');
 			$this->addData('Client IP', $this->app['request']->getClientIp());
+			$this->addData('User Agent', $this->app['request']->header('User-Agent'));
 
 			list($routeAction, $routeName) = $this->findRouteNames();
 			if ($routeName)   $this->addData('Route name', $routeName);

--- a/src/anlutro/L4SmartErrors/Log/ContextCollector.php
+++ b/src/anlutro/L4SmartErrors/Log/ContextCollector.php
@@ -50,6 +50,7 @@ class ContextCollector
 			$context['input']       = $this->sanitizeInput($request->input());
 			$context['referer']     = $request->header('referer') ?: 'None';
 			$context['client_ip']   = $request->getClientIp();
+			$context['user_agent']  = $request->header('User-Agent');
 			$context['session_id']  = $this->app['session']->getId();
 
 			list($routeAction, $routeName) = $this->findRouteNames();

--- a/tests/unit/AppInfoGeneratorTest.php
+++ b/tests/unit/AppInfoGeneratorTest.php
@@ -61,6 +61,7 @@ class AppInfoGeneratorTest extends PHPUnit_Framework_TestCase
 		$this->assertContains('Client IP: 127.0.0.1', $strings);
 		$this->assertContains('Route name: route.name', $strings);
 		$this->assertContains('Route action: Controller@method', $strings);
+		$this->assertContains('User Agent: Symfony/2.X', $strings);
 	}
 
 	/** @test */


### PR DESCRIPTION
I tested this manually and it seems to be working; I can see the user agent in both the error email and the logs.

I was going to try adding a test, but the `user_agent` comes back as `NULL`. (As does `client_ip`, I noticed.) Any ideas for how best to simulate that?