### PR TITLE
Add sanitized session data to emails

### DIFF
--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -316,7 +316,7 @@ class ErrorHandler
 		}
 
 		return $this->app->make('anlutro\L4SmartErrors\Presenters\InputPresenter',
-			[$input]);
+			[$input, ["password"]]);
 	}
 
 	/**

--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -13,15 +13,12 @@ use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\TokenMismatchException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use anlutro\L4SmartErrors\Traits\SanitizeTrait;
 
 /**
  * The class that handles the errors. Obviously
  */
 class ErrorHandler
 {
-	use SanitizeTrait;
-
 	/**
 	 * @var \Illuminate\Foundation\Application
 	 */
@@ -33,17 +30,11 @@ class ErrorHandler
 	protected $handledExceptions;
 
 	/**
-	 * @var array
-	 */
-	protected $sanitizeFields;
-
-	/**
 	 * @param \Illuminate\Foundation\Application $app
 	 */
 	public function __construct(Application $app)
 	{
 		$this->app = $app;
-		$this->sanitizeFields = $this->app['config']->get('smarterror::session-wipe');
 		$this->handledExceptions = new \SplObjectStorage;
 	}
 
@@ -302,14 +293,13 @@ class ErrorHandler
 	protected function makeSessionPresenter()
 	{
 		$session = $this->app['session']->all();
-
-		$session = $this->sanitize($session, $this->sanitizeFields);
+		$fields = $this->app['config']->get('smarterror::session-wipe');
 
 		if (count($session) < 1) {
 			return null;
 		}
 
-		return $this->app->make('anlutro\L4SmartErrors\Presenters\SessionPresenter', [$session]);
+		return $this->app->make('anlutro\L4SmartErrors\Presenters\SessionPresenter', [$session, $fields]);
 	}
 
 	/**

--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -294,6 +294,10 @@ class ErrorHandler
 	{
 		$session = $this->app['session']->all();
 
+		foreach ($this->app['config']->get('session-wipe') as $key) {
+			unset($session[$key]);
+		}
+
 		if (count($session) < 1) {
 			return null;
 		}

--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -13,12 +13,15 @@ use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\TokenMismatchException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use anlutro\L4SmartErrors\Traits\SanitizeTrait;
 
 /**
  * The class that handles the errors. Obviously
  */
 class ErrorHandler
 {
+	use SanitizeTrait;
+
 	/**
 	 * @var \Illuminate\Foundation\Application
 	 */
@@ -292,27 +295,6 @@ class ErrorHandler
 	}
 
 	/**
-	 * Sanitize an array.
-	 *
-	 * @return array
-	 */
-	protected function sanitize(array $input)
-	{
-		foreach ($input as $key => &$value) {
-			if (is_array($value)) {
-				$value = $this->sanitize($value);
-			}
-			foreach ($this->sanitizeFields as $field) {
-				if (strpos(strtolower($key), $field) !== false) {
-					$value = 'HIDDEN';
-				}
-			}
-		}
-
-		return $input;
-	}
-
-	/**
 	 * Make a session presenter.
 	 *
 	 * @return \anlutro\L4SmartErrors\Presenters\SessionPresenter|null
@@ -321,7 +303,7 @@ class ErrorHandler
 	{
 		$session = $this->app['session']->all();
 
-		$session = $this->sanitize($session);
+		$session = $this->sanitize($session, $this->sanitizeFields);
 
 		if (count($session) < 1) {
 			return null;

--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -89,11 +89,12 @@ class ErrorHandler
 			if ($email && $this->shouldSendEmail($exception)) {
 				$appInfoGenerator = $this->makeAppInfoGenerator();
 				$exceptionPresenter = $this->makeExceptionPresenter($exception);
+				$sessionPresenter = $this->makeSessionPresenter();
 				$inputPresenter = $this->makeInputPresenter();
 				$queryLogPresenter = $this->makeQueryLogPresenter();
 
 				$this->app->make('anlutro\L4SmartErrors\Mail\ExceptionMailer',
-					[$this->app, $exceptionPresenter, $appInfoGenerator, $inputPresenter, $queryLogPresenter])
+					[$this->app, $exceptionPresenter, $sessionPresenter, $appInfoGenerator, $inputPresenter, $queryLogPresenter])
 					->send($email);
 			}
 
@@ -282,6 +283,22 @@ class ErrorHandler
 	{
 		return $this->app->make('anlutro\L4SmartErrors\Log\ContextCollector',
 			[$this->app]);
+	}
+
+	/**
+	 * Make a session presenter.
+	 *
+	 * @return \anlutro\L4SmartErrors\Presenters\SessionPresenter|null
+	 */
+	protected function makeSessionPresenter()
+	{
+		$session = $this->app['session']->all();
+
+		if (count($session) < 1) {
+			return null;
+		}
+
+		return $this->app->make('anlutro\L4SmartErrors\Presenters\SessionPresenter', [$session]);
 	}
 
 	/**

--- a/src/anlutro/L4SmartErrors/Mail/ExceptionMailer.php
+++ b/src/anlutro/L4SmartErrors/Mail/ExceptionMailer.php
@@ -13,6 +13,7 @@ use Exception;
 use Illuminate\Foundation\Application;
 use anlutro\L4SmartErrors\AppInfoGenerator;
 use anlutro\L4SmartErrors\Presenters\ExceptionPresenter;
+use anlutro\L4SmartErrors\Presenters\SessionPresenter;
 use anlutro\L4SmartErrors\Presenters\InputPresenter;
 use anlutro\L4SmartErrors\Presenters\QueryLogPresenter;
 use Illuminate\Mail\Message;
@@ -21,6 +22,7 @@ class ExceptionMailer
 {
 	protected $app;
 	protected $exception;
+	protected $session;
 	protected $appInfo;
 	protected $input;
 	protected $queryLog;
@@ -28,12 +30,14 @@ class ExceptionMailer
 	public function __construct(
 		Application $app,
 		ExceptionPresenter $exception,
+		SessionPresenter $session,
 		AppInfoGenerator $appInfo,
 		InputPresenter $input = null,
 		QueryLogPresenter $queryLog = null
 	) {
 		$this->app = $app;
 		$this->exception = $exception;
+		$this->session = $session;
 		$this->appInfo = $appInfo;
 		$this->input = $input;
 		$this->queryLog = $queryLog;
@@ -54,6 +58,7 @@ class ExceptionMailer
 		$mailData = array(
 			'info'      => $this->appInfo,
 			'exception' => $this->exception,
+			'session'   => $this->session,
 			'input'     => $this->input,
 			'queryLog'  => $this->queryLog,
 		);

--- a/src/anlutro/L4SmartErrors/Presenters/InputPresenter.php
+++ b/src/anlutro/L4SmartErrors/Presenters/InputPresenter.php
@@ -8,14 +8,17 @@
  */
 
 namespace anlutro\L4SmartErrors\Presenters;
+use anlutro\L4SmartErrors\Traits\SanitizeTrait;
 
 class InputPresenter extends AbstractPresenter
 {
+	use SanitizeTrait;
+
 	protected $input;
 
-	public function __construct(array $input)
+	public function __construct(array $input, array $fields)
 	{
-		$this->input = $input;
+		$this->input = $this->sanitize($input, $fields);
 	}
 
 	public function renderHtml()

--- a/src/anlutro/L4SmartErrors/Presenters/SessionPresenter.php
+++ b/src/anlutro/L4SmartErrors/Presenters/SessionPresenter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Laravel 4 Smart Errors
+ *
+ * @author    Andreas Lutro <anlutro@gmail.com>
+ * @license   http://opensource.org/licenses/MIT
+ * @package   l4-smart-errors
+ */
+
+namespace anlutro\L4SmartErrors\Presenters;
+
+class SessionPresenter extends AbstractPresenter
+{
+	protected $session;
+
+	public function __construct(array $session)
+	{
+		$this->session = $session;
+	}
+
+	public function renderHtml()
+	{
+		return $this->renderVarDump($this->session, true);
+	}
+
+	public function renderPlain()
+	{
+		return $this->renderVarDump($this->session, false);
+	}
+
+	public function renderCompact()
+	{
+		return json_encode($this->session);
+	}
+}

--- a/src/anlutro/L4SmartErrors/Presenters/SessionPresenter.php
+++ b/src/anlutro/L4SmartErrors/Presenters/SessionPresenter.php
@@ -9,13 +9,17 @@
 
 namespace anlutro\L4SmartErrors\Presenters;
 
+use anlutro\L4SmartErrors\Traits\SanitizeTrait;
+
 class SessionPresenter extends AbstractPresenter
 {
+	use SanitizeTrait;
+
 	protected $session;
 
-	public function __construct(array $session)
+	public function __construct(array $session, array $sanitizeFields)
 	{
-		$this->session = $session;
+		$this->session = $this->sanitize($session, $sanitizeFields);
 	}
 
 	public function renderHtml()

--- a/src/anlutro/L4SmartErrors/Traits/SanitizeTrait.php
+++ b/src/anlutro/L4SmartErrors/Traits/SanitizeTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Laravel 4 Smart Errors
+ *
+ * @author    Andreas Lutro <anlutro@gmail.com>
+ * @license   http://opensource.org/licenses/MIT
+ * @package   l4-smart-errors
+ */
+
+namespace anlutro\L4SmartErrors\Traits;
+
+trait SanitizeTrait
+{
+	/**
+	 * Sanitize the $data array by overwriting any keys found in $sanitize
+	 * with "HIDDEN".
+	 *
+	 * @return array
+	 */
+	protected function sanitize($data, $sanitize)
+	{
+		foreach ($data as $key => &$value) {
+			if (is_array($value)) {
+				$value = $this->sanitize($value, $sanitize);
+			}
+			foreach ($sanitize as $field) {
+				if (strpos(strtolower($key), $field) !== false) {
+					$value = 'HIDDEN';
+				}
+			}
+		}
+
+		return $data;
+	}
+}
+
+?>

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -53,6 +53,9 @@ return array(
 	// Path to JSON file where metadata is stored.
 	'storage-path' => storage_path('meta/l4-smart-errors.json'),
 
+	// Sensitive keys that should be cleared from the session
+	'session-wipe' => [],
+
 	// The error handler has a throttle in place to prevent the same exception
 	// from being emailed over and over. This is the number of seconds that must
 	// have passed since the last exception of the same type for the new

--- a/src/views/error-email-plain.php
+++ b/src/views/error-email-plain.php
@@ -23,6 +23,13 @@ Input
 =====
 <?php echo $input->renderPlain(); ?>
 <?php endif; ?>
+<?php if ($session): ?>
+
+
+Session
+=======
+<?php echo $session->renderPlain(); ?>
+<?php endif; ?>
 <?php if ($queryLog): ?>
 
 

--- a/src/views/error-email.php
+++ b/src/views/error-email.php
@@ -24,6 +24,12 @@
 </p>
 <?php endif; ?>
 
+<?php if ($session): ?>
+	<hr>
+	<p><b>Session</b></p>
+	<p><?php echo $session->renderHtml(); ?></p>
+<?php endif; ?>
+
 <?php if ($queryLog): ?>
 <hr>
 <p>

--- a/tests/functional/ErrorHandlingTest.php
+++ b/tests/functional/ErrorHandlingTest.php
@@ -30,6 +30,8 @@ class ErrorHandlingTest extends PkgAppTestCase
 		$this->app['config']->set('mail.pretend', false);
 		$this->app['config']->set('mail.from', ['name' => 'FooBar', 'address' => 'foo@bar.com']);
 
+		$this->app['session']->set('foo', 'bar');
+
 		$this->app['router']->get('exception', function() {
 			throw new \LogicException('L4SmartErrors test exception');
 		});

--- a/tests/functional/ErrorHandlingTest.php
+++ b/tests/functional/ErrorHandlingTest.php
@@ -31,6 +31,8 @@ class ErrorHandlingTest extends PkgAppTestCase
 		$this->app['config']->set('mail.from', ['name' => 'FooBar', 'address' => 'foo@bar.com']);
 
 		$this->app['session']->set('foo', 'bar');
+		$this->app['session']->set('password', 'SuperSecret');
+		$this->app['session']->set('nested.foo.password', 'OtherSecretStuff');
 
 		$this->app['router']->get('exception', function() {
 			throw new \LogicException('L4SmartErrors test exception');
@@ -311,6 +313,15 @@ class ErrorHandlingTest extends PkgAppTestCase
 			->andReturnUsing(function($msg) {
 				$this->assertEquals(['dev1@test.com' => null, 'dev2@test.com' => null], $msg->getTo());
 			});
+		$this->call('get', '/exception');
+	}
+
+	/** @test */
+	public function sessionIsSanitized()
+	{
+		$this->app['config']->set('smarterror::session-wipe', ['password']);
+		$this->expectMailBodiesContain(["'password' =>\n  string(6) \"HIDDEN\"",
+		                                "'password' =>\n      string(6) \"HIDDEN\""]);
 		$this->call('get', '/exception');
 	}
 }

--- a/tests/unit/ExceptionMailerTest.php
+++ b/tests/unit/ExceptionMailerTest.php
@@ -37,6 +37,11 @@ class ExceptionMailerTest extends PHPUnit_Framework_TestCase
 		return $mock;
 	}
 
+	protected function makeSessionPresenter($session)
+	{
+		return new \anlutro\L4SmartErrors\Presenters\SessionPresenter($session);
+	}
+
 	protected function mockAppInfoGenerator()
 	{
 		return m::mock('anlutro\L4SmartErrors\AppInfoGenerator');
@@ -52,26 +57,27 @@ class ExceptionMailerTest extends PHPUnit_Framework_TestCase
 		return new \anlutro\L4SmartErrors\Presenters\QueryLogPresenter($queryLog);
 	}
 
-	protected function makeMailer($app, $exception, $appInfo, $input = null, $queryLog = null)
+	protected function makeMailer($app, $exception, $session, $appInfo, $input = null, $queryLog = null)
 	{
-		return new \anlutro\L4SmartErrors\Mail\ExceptionMailer($app, $exception, $appInfo, $input, $queryLog);
+		return new \anlutro\L4SmartErrors\Mail\ExceptionMailer($app, $exception, $session, $appInfo, $input, $queryLog);
 	}
 
 	protected function makeEverything()
 	{
 		$app = $this->makeApp(['smarterror::email-from' => 'bar@baz.com', 'smarterror::cc-email' => 'cc-me@example.com']);
 		$exception = $this->mockExceptionPresenter(new TestException);
+		$session = $this->makeSessionPresenter(['foo'=>'bar']);
 		$appInfo = $this->mockAppInfoGenerator();
 		$input = $this->makeInputPresenter();
 		$queryLog = $this->makeQueryLogPresenter();
-		$mailer = $this->makeMailer($app, $exception, $appInfo, $input, $queryLog);
-		return [$mailer, $app, $exception, $appInfo, $input, $queryLog];
+		$mailer = $this->makeMailer($app, $exception, $session, $appInfo, $input, $queryLog);
+		return [$mailer, $app, $exception, $session, $appInfo, $input, $queryLog];
 	}
 
 	/** @test */
 	public function everything()
 	{
-		list($mailer, $app, $exception, $appInfo, $input, $queryLog) = $this->makeEverything();
+		list($mailer, $app, $exception, $session, $appInfo, $input, $queryLog) = $this->makeEverything();
 
 		$app['request']->shouldReceive('root')->once()->andReturn('http://localhost');
 		$app['mailer']->shouldReceive('send')->once()

--- a/tests/unit/ExceptionMailerTest.php
+++ b/tests/unit/ExceptionMailerTest.php
@@ -49,7 +49,7 @@ class ExceptionMailerTest extends PHPUnit_Framework_TestCase
 
 	protected function makeInputPresenter($input = array())
 	{
-		return new \anlutro\L4SmartErrors\Presenters\InputPresenter($input);
+		return new \anlutro\L4SmartErrors\Presenters\InputPresenter($input, ["password"]);
 	}
 
 	protected function makeQueryLogPresenter($queryLog = array())

--- a/tests/unit/ExceptionMailerTest.php
+++ b/tests/unit/ExceptionMailerTest.php
@@ -39,7 +39,7 @@ class ExceptionMailerTest extends PHPUnit_Framework_TestCase
 
 	protected function makeSessionPresenter($session)
 	{
-		return new \anlutro\L4SmartErrors\Presenters\SessionPresenter($session);
+		return new \anlutro\L4SmartErrors\Presenters\SessionPresenter($session, []);
 	}
 
 	protected function mockAppInfoGenerator()

--- a/tests/unit/InputPresenterTest.php
+++ b/tests/unit/InputPresenterTest.php
@@ -27,6 +27,6 @@ class InputPresenterTest extends PHPUnit_Framework_TestCase
 
 	public function makePresenter(array $input)
 	{
-		return new anlutro\L4SmartErrors\Presenters\InputPresenter($input);
+		return new anlutro\L4SmartErrors\Presenters\InputPresenter($input, ["password"]);
 	}
 }


### PR DESCRIPTION
Here's my attempt at adding the Session data to the emails (see #26).

I copied the sanitize function from the one in `ContextCollector.php`, because I couldn't figure out a good way to use the same function for both.