### PR TITLE
Allow this to work in Laravel 4.2 on PHP 7

### DIFF
--- a/src/anlutro/L4SmartErrors/ErrorHandler.php
+++ b/src/anlutro/L4SmartErrors/ErrorHandler.php
@@ -9,7 +9,6 @@
 
 namespace anlutro\L4SmartErrors;
 
-use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\TokenMismatchException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -71,7 +70,7 @@ class ErrorHandler
 	 *
 	 * @return \Illuminate\Http\Response|null
 	 */
-	public function handleException(Exception $exception, $code = null)
+	public function handleException($exception, $code = null)
 	{
 		try {
 			if ($this->exceptionHasBeenHandled($exception)) {
@@ -200,7 +199,7 @@ class ErrorHandler
 	 *
 	 * @return boolean
 	 */
-	protected function exceptionHasBeenHandled(Exception $exception)
+	protected function exceptionHasBeenHandled($exception)
 	{
 		if ($this->handledExceptions->contains($exception)) {
 			return true;
@@ -218,7 +217,7 @@ class ErrorHandler
 	 *
 	 * @return string
 	 */
-	protected function handleHandlerException(Exception $exception)
+	protected function handleHandlerException($exception)
 	{
 		error_log('Error in exception handler - https://github.com/anlutro/laravel-4-smart-errors/issues');
 
@@ -237,7 +236,7 @@ class ErrorHandler
 	 *
 	 * @return boolean
 	 */
-	protected function shouldSendEmail(Exception $exception)
+	protected function shouldSendEmail($exception)
 	{
 		// if the mailer is not bound to the IoC container...
 		if (!$this->app->bound('mailer') && !$this->app->isDeferredService('mailer')) {
@@ -257,7 +256,7 @@ class ErrorHandler
 	 *
 	 * @return \anlutro\L4SmartErrors\Presenters\ExceptionPresenter
 	 */
-	protected function makeExceptionPresenter(Exception $exception)
+	protected function makeExceptionPresenter($exception)
 	{
 		return $this->app->make('anlutro\L4SmartErrors\Presenters\ExceptionPresenter',
 			[$exception]);

--- a/src/anlutro/L4SmartErrors/L4SmartErrorsServiceProvider.php
+++ b/src/anlutro/L4SmartErrors/L4SmartErrorsServiceProvider.php
@@ -51,7 +51,7 @@ class L4SmartErrorsServiceProvider extends ServiceProvider
 	protected function registerErrorHandler()
 	{
 		$app = $this->app;
-		$this->app->error(function(\Exception $exception, $code) use ($app) {
+		$this->app->error(function($exception, $code) use ($app) {
 			return $app['smarterror']->handleException($exception, $code);
 		});
 	}

--- a/src/anlutro/L4SmartErrors/Log/ExceptionLogger.php
+++ b/src/anlutro/L4SmartErrors/Log/ExceptionLogger.php
@@ -9,7 +9,6 @@
 
 namespace anlutro\L4SmartErrors\Log;
 
-use Exception;
 use Psr\Log\LoggerInterface;
 
 class ExceptionLogger
@@ -25,7 +24,7 @@ class ExceptionLogger
 		$this->contextCollector = $contextCollector;
 	}
 
-	public function log(Exception $exception)
+	public function log($exception)
 	{
 		$logstr = "Uncaught $exception";
 

--- a/src/anlutro/L4SmartErrors/Mail/ExceptionMailer.php
+++ b/src/anlutro/L4SmartErrors/Mail/ExceptionMailer.php
@@ -9,7 +9,6 @@
 
 namespace anlutro\L4SmartErrors\Mail;
 
-use Exception;
 use Illuminate\Foundation\Application;
 use anlutro\L4SmartErrors\AppInfoGenerator;
 use anlutro\L4SmartErrors\Presenters\ExceptionPresenter;
@@ -92,7 +91,7 @@ class ExceptionMailer
 		$this->app['mailer']->send(array($htmlView, $plainView), $mailData, $callback);
 	}
 
-	protected function getExceptionBaseName(Exception $exception)
+	protected function getExceptionBaseName($exception)
 	{
 		$exceptionName = get_class($exception);
 

--- a/src/anlutro/L4SmartErrors/Presenters/ExceptionPresenter.php
+++ b/src/anlutro/L4SmartErrors/Presenters/ExceptionPresenter.php
@@ -9,7 +9,6 @@
 
 namespace anlutro\L4SmartErrors\Presenters;
 
-use Exception;
 use Xethron\L4ToString;
 
 class ExceptionPresenter
@@ -18,7 +17,7 @@ class ExceptionPresenter
 	protected $exception;
 	protected $descriptive = false;
 
-	public function __construct(Exception $exception)
+	public function __construct($exception)
 	{
 		$this->exception = $exception;
 

--- a/src/anlutro/L4SmartErrors/ReportThrottler.php
+++ b/src/anlutro/L4SmartErrors/ReportThrottler.php
@@ -9,7 +9,6 @@
 
 namespace anlutro\L4SmartErrors;
 
-use Exception;
 use Carbon\Carbon;
 use Illuminate\Config\Repository;
 use Illuminate\Filesystem\Filesystem;
@@ -38,7 +37,7 @@ class ReportThrottler
 	 *
 	 * @return boolean
 	 */
-	public function shouldReport(Exception $exception)
+	public function shouldReport($exception)
 	{
 		// if app.debug is true, reporting is unnecessary
 		if ($this->config->get('app.debug') === true) {

--- a/src/anlutro/L4SmartErrors/Responders/ExceptionResponder.php
+++ b/src/anlutro/L4SmartErrors/Responders/ExceptionResponder.php
@@ -9,14 +9,13 @@
 
 namespace anlutro\L4SmartErrors\Responders;
 
-use Exception;
 use Illuminate\Support\Facades\Response;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class ExceptionResponder extends AbstractResponder
 {
-	public function respond(Exception $exception)
+	public function respond($exception)
 	{
 		// the default laravel console error handler really sucks - override it
 		if ($this->isConsole()) {


### PR DESCRIPTION
This will allow this package to work correctly on PHP 7.

Ideally, `Exception` would be changed to `Throwable`, but that wouldn't be backwards compatible, and as this package hasn't been actively developed for a while, I thought this quick fix would be the best solution.

Thanks